### PR TITLE
Add 14 tests (Trakt + GA4 + privacy) and sync docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,13 +145,14 @@ All code-review findings from both reviews (initial + 2026-04-18 full-repo audit
 
 ## Testing
 
-72 tests across 3 files. Run with `python3 -m pytest tests/ -v` (requires `pytest`).
+86 tests across 4 files. Run with `python3 -m pytest tests/ -v` (requires `pytest`).
 
 | File | Type | Tests | What it covers |
 |------|------|-------|---------------|
 | `tests/test_shared.py` | Unit | 37 | `_shared.py`: escape_html, relative_time, replace_marker, content_changed, sanitize_error, record_heartbeat (incl. corrupt JSON recovery) |
 | `tests/test_feeds.py` | Unit | 19 | `update-whoop.py`: recovery_color; `update-public-feeds.py`: ordinal |
-| `tests/test_site_e2e.py` | E2E | 16 | All HTML pages: meta tags, CSP, aria-pressed, JSON-LD, images, feed markers, OpenSSL parity, dark mode parity |
+| `tests/test_trakt.py` | Unit | 10 | `update-trakt.py`: build_html rendering, HTML escaping, deduplication by show, 5-show limit |
+| `tests/test_site_e2e.py` | E2E | 20 | All HTML pages: meta tags, CSP, aria-pressed, JSON-LD, images, feed markers, OpenSSL parity, dark mode parity, GA4 presence, privacy policy accuracy |
 
 CI runs on push to `main` via `.github/workflows/ci-tests.yml`. See `docs/test-plan.md` for the full testing strategy.
 

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -4,7 +4,7 @@ Testing strategy, inventory, and execution cadence for the site and its automati
 
 ## Test Types
 
-### Unit Tests (`tests/test_shared.py`, `tests/test_feeds.py`)
+### Unit Tests (`tests/test_shared.py`, `tests/test_feeds.py`, `tests/test_trakt.py`)
 
 **What they test:** Individual Python functions in isolation — the pure logic that transforms data, escapes HTML, formats time, and replaces content markers.
 
@@ -21,6 +21,7 @@ python3 -m pytest tests/ -v
 |-----------|--------|-----------------|
 | `tests/test_shared.py` | `bin/_shared.py` | `escape_html`, `relative_time`, `replace_marker`, `content_changed`, `sanitize_error`, `record_heartbeat` (incl. corrupt JSON recovery) |
 | `tests/test_feeds.py` | `bin/update-whoop.py`, `bin/update-public-feeds.py` | `recovery_color`, `ordinal` |
+| `tests/test_trakt.py` | `bin/update-trakt.py` | `build_html` (rendering, escaping, empty state), `fetch_recent_shows` (deduplication, 5-show limit) |
 
 ### E2E Tests (`tests/test_site_e2e.py`)
 
@@ -49,6 +50,10 @@ python3 -m pytest tests/test_site_e2e.py -v
 | Print stylesheet | Key print-only elements exist in `index.html` |
 | OpenSSL parity | All `openssl enc` calls use matching `-iter 600000` |
 | Dark mode parity | `@media (prefers-color-scheme: dark)` count matches `[data-theme="dark"]` count in CSS |
+| GA4 presence | GA4 snippet (G-B3HW5VBDB3) present on all pages |
+| GA4 CSP | CSP allows googletagmanager.com on all pages |
+| Privacy feeds | Privacy policy lists all 6 feed data sources |
+| Privacy GA4 | Privacy policy discloses GA4 measurement ID |
 
 ## Execution Cadence Summary
 
@@ -69,4 +74,4 @@ python3 -m pytest tests/test_site_e2e.py -v
 
 Tests run in CI via `.github/workflows/ci-tests.yml`. Results are visible in the GitHub Actions tab. Failures block nothing (this is a single-contributor repo with direct push), but they surface regressions early.
 
-Last updated: 2026-04-19
+Last updated: 2026-04-21

--- a/llms.txt
+++ b/llms.txt
@@ -26,9 +26,14 @@ The site includes a Derek Sivers-style /now page at https://jameschang.co/now/ w
 - Letterboxd: recently watched films
 - Goodreads: recently read books
 - The Fantastic Leagues: fantasy baseball team standings
+- Trakt (every 6 hours): recently watched TV shows
 - Thirsty Pig hit list: restaurants to try (client-side fetch)
 
 The /now page also lists active projects, back-burner work, and what James is currently exploring (Obsidian integration, OpenClaw).
+
+## Analytics
+
+Google Analytics 4 (measurement ID G-B3HW5VBDB3) is installed on all pages. IP addresses are anonymized. No PII is collected.
 
 ## Previous roles
 

--- a/tests/test_site_e2e.py
+++ b/tests/test_site_e2e.py
@@ -351,6 +351,47 @@ class TestDarkModeParity:
         assert not failures, f"Dark mode selector imbalance:\n" + "\n".join(failures)
 
 
+# ── Tests: GA4 ───────────────────────────────────────────────────
+
+class TestGA4:
+    """Google Analytics 4 must be present on all pages."""
+
+    def test_ga4_snippet_on_all_pages(self):
+        failures = []
+        for f in HTML_FILES:
+            _, body = fetch(f)
+            if "G-B3HW5VBDB3" not in body:
+                failures.append(f)
+        assert not failures, f"Missing GA4 snippet:\n" + "\n".join(failures)
+
+    def test_csp_allows_google(self):
+        failures = []
+        for f in HTML_FILES:
+            _, body = fetch(f)
+            p = parse_page(body)
+            csp = p.metas.get("content-security-policy", "")
+            if "googletagmanager.com" not in csp:
+                failures.append(f"{f}: missing googletagmanager.com in CSP")
+        assert not failures, f"CSP missing Google domains:\n" + "\n".join(failures)
+
+
+# ── Tests: Privacy policy accuracy ───────────────────────────────
+
+class TestPrivacyPolicy:
+    """Privacy policy must accurately reflect site data practices."""
+
+    def test_lists_all_feed_sources(self):
+        _, body = fetch("privacy/index.html")
+        required = ["GitHub", "MLB", "Letterboxd", "Trakt", "Goodreads", "Fantastic Leagues"]
+        missing = [src for src in required if src not in body]
+        assert not missing, f"Privacy policy missing feed sources: {missing}"
+
+    def test_mentions_ga4(self):
+        _, body = fetch("privacy/index.html")
+        assert "Google Analytics 4" in body, "Privacy policy does not mention GA4"
+        assert "G-B3HW5VBDB3" in body, "Privacy policy does not mention measurement ID"
+
+
 # ── Tests: Print stylesheet ──────────────────────────────────────
 
 class TestPrintStylesheet:

--- a/tests/test_trakt.py
+++ b/tests/test_trakt.py
@@ -1,0 +1,141 @@
+"""Unit tests for bin/update-trakt.py — Trakt TV feed rendering."""
+
+import importlib
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "bin"))
+
+_trakt = importlib.import_module("update-trakt")
+build_html = _trakt.build_html
+fetch_recent_shows = _trakt.fetch_recent_shows
+
+
+# ── build_html ───────────────────────────────────────────────────
+
+class TestBuildHtml:
+    def test_single_show(self):
+        shows = [{
+            "show": "Pluribus",
+            "season": 1,
+            "episode": 9,
+            "episode_title": "La Chica o El Mundo",
+            "watched_at": "2026-04-20T18:41:00.000Z",
+            "url": "https://trakt.tv/shows/pluribus",
+        }]
+        html = build_html(shows)
+        assert "Pluribus" in html
+        assert "S01E09" in html
+        assert "La Chica o El Mundo" in html
+        assert "trakt.tv/shows/pluribus" in html
+        assert "trakt-list" in html
+
+    def test_multiple_shows(self):
+        shows = [
+            {"show": "Show A", "season": 2, "episode": 3, "episode_title": "Ep", "watched_at": None, "url": ""},
+            {"show": "Show B", "season": 1, "episode": 1, "episode_title": "Pilot", "watched_at": None, "url": ""},
+        ]
+        html = build_html(shows)
+        assert "Show A" in html
+        assert "Show B" in html
+        assert html.count("<li>") == 2
+
+    def test_empty_shows_returns_fallback(self):
+        html = build_html([])
+        assert "No shows tracked recently" in html
+        assert "trakt-list" not in html
+
+    def test_html_escapes_show_title(self):
+        shows = [{
+            "show": "Tom & Jerry's <Show>",
+            "season": 1,
+            "episode": 1,
+            "episode_title": "",
+            "watched_at": None,
+            "url": "",
+        }]
+        html = build_html(shows)
+        assert "Tom &amp; Jerry&#39;s &lt;Show&gt;" in html
+        assert "<Show>" not in html  # raw HTML not present
+
+    def test_episode_without_title(self):
+        shows = [{
+            "show": "Test",
+            "season": 3,
+            "episode": 5,
+            "episode_title": "",
+            "watched_at": None,
+            "url": "",
+        }]
+        html = build_html(shows)
+        assert "S03E05" in html
+        assert "ldquo" not in html  # no quotes around empty title
+
+    def test_show_without_season_episode(self):
+        shows = [{
+            "show": "Movie Night",
+            "season": None,
+            "episode": None,
+            "episode_title": "",
+            "watched_at": None,
+            "url": "",
+        }]
+        html = build_html(shows)
+        assert "Movie Night" in html
+        assert "S00" not in html  # no season/episode formatting
+
+    def test_auto_updated_line_present(self):
+        html = build_html([])
+        assert "Auto-updated" in html
+        assert "Trakt" in html
+
+
+# ── fetch_recent_shows (deduplication logic) ─────────────────────
+
+class TestFetchDeduplication:
+    """Test the deduplication logic without making API calls.
+
+    fetch_recent_shows calls api_get internally, so we mock it
+    to test the show-deduplication and limit logic.
+    """
+
+    def test_deduplicates_by_show_name(self, monkeypatch):
+        fake_data = [
+            {"show": {"title": "Pluribus", "ids": {"slug": "pluribus"}},
+             "episode": {"season": 1, "number": 9, "title": "Ep 9"},
+             "watched_at": "2026-04-20T18:41:00Z"},
+            {"show": {"title": "Pluribus", "ids": {"slug": "pluribus"}},
+             "episode": {"season": 1, "number": 8, "title": "Ep 8"},
+             "watched_at": "2026-04-20T18:40:00Z"},
+            {"show": {"title": "The West Wing", "ids": {"slug": "the-west-wing"}},
+             "episode": {"season": 7, "number": 22, "title": "Tomorrow"},
+             "watched_at": "2026-04-19T20:00:00Z"},
+        ]
+        monkeypatch.setattr(_trakt, "api_get", lambda token, path, params=None: fake_data)
+        monkeypatch.setenv("TRAKT_CLIENT_ID", "fake")
+
+        shows = fetch_recent_shows("fake_token")
+        assert len(shows) == 2
+        assert shows[0]["show"] == "Pluribus"
+        assert shows[0]["episode"] == 9  # most recent episode
+        assert shows[1]["show"] == "The West Wing"
+
+    def test_limits_to_five_shows(self, monkeypatch):
+        fake_data = [
+            {"show": {"title": f"Show {i}", "ids": {"slug": f"show-{i}"}},
+             "episode": {"season": 1, "number": 1, "title": "Pilot"},
+             "watched_at": f"2026-04-{20-i:02d}T00:00:00Z"}
+            for i in range(10)
+        ]
+        monkeypatch.setattr(_trakt, "api_get", lambda token, path, params=None: fake_data)
+        monkeypatch.setenv("TRAKT_CLIENT_ID", "fake")
+
+        shows = fetch_recent_shows("fake_token")
+        assert len(shows) == 5
+
+    def test_empty_api_response(self, monkeypatch):
+        monkeypatch.setattr(_trakt, "api_get", lambda token, path, params=None: [])
+        monkeypatch.setenv("TRAKT_CLIENT_ID", "fake")
+
+        shows = fetch_recent_shows("fake_token")
+        assert shows == []


### PR DESCRIPTION
## Summary
- 10 unit tests for `update-trakt.py`: HTML rendering, escaping, deduplication, limits
- 4 E2E tests: GA4 on all pages, CSP allows Google, privacy policy accuracy
- Doc sync: test-plan.md, llms.txt, CLAUDE.md all updated to match reality (86 tests)

## Test plan
- [x] `python3 -m pytest tests/ -v` — 86 passed locally
- [x] CI will run on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)