### PR TITLE
docs: sync all docs — fix drift from session work

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ Personal site for James Chang — founder of Aleph Co. and senior product manage
 | `index.html` | Homepage — hero, about, experience, education, skills, projects, case studies, testimonials |
 | `styles.css` | Design system (CSS custom properties) + `@media print` resume stylesheet |
 | `script.js` | Theme toggle (light/dark) + headshot rotation (crossfade, respects reduced-motion) |
-| `now/index.html` | Derek Sivers-style /now page with 8 automated data feeds |
+| `now/index.html` | Derek Sivers-style /now page with 11 automated data feeds |
 | `work/` | Deep-dive project pages (Aleph, Fantastic Leagues, Judge Tool) |
 | `work/work.css` | Shared styles for /work and /now pages |
 | `privacy/` | Privacy policy (required by WHOOP/Spotify app registrations) |
-| `bin/` | Python sync scripts (WHOOP, Spotify, public feeds) |
+| `bin/` | Python sync scripts (WHOOP, Spotify, Trakt, Plex, public feeds) |
 | `.github/workflows/` | GitHub Actions for automated feed updates + staleness monitoring |
 
 ## Local preview
@@ -40,7 +40,9 @@ python3 -m http.server 8787 &
 - System font stacks (no web fonts)
 - Dark mode via `prefers-color-scheme` + manual toggle (persisted in localStorage)
 - WCAG 2.2 AA compliant. Lighthouse 100/100/100/100.
-- 8 automated data feeds on /now (WHOOP, Spotify, GitHub, MLB, Letterboxd, Goodreads, FBST, Thirsty Pig hitlist)
+- 11 automated data feeds on /now (WHOOP, Spotify, Trakt, Plex, GitHub, MLB, Letterboxd, Goodreads currently-reading, Goodreads read, FBST, Thirsty Pig hitlist)
+- 137 tests (pytest) with pre-commit hook and CI
+- Google Analytics 4 + Google Search Console
 
 ## License
 

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -4,7 +4,7 @@ Testing strategy, inventory, and execution cadence for the site and its automati
 
 ## Test Types
 
-### Unit Tests (`tests/test_shared.py`, `tests/test_feeds.py`, `tests/test_trakt.py`)
+### Unit Tests (6 files)
 
 **What they test:** Individual Python functions in isolation — the pure logic that transforms data, escapes HTML, formats time, and replaces content markers.
 
@@ -22,6 +22,9 @@ python3 -m pytest tests/ -v
 | `tests/test_shared.py` | `bin/_shared.py` | `escape_html`, `relative_time`, `replace_marker`, `content_changed`, `sanitize_error`, `record_heartbeat` (incl. corrupt JSON recovery) |
 | `tests/test_feeds.py` | `bin/update-whoop.py`, `bin/update-public-feeds.py` | `recovery_color`, `ordinal` |
 | `tests/test_trakt.py` | `bin/update-trakt.py` | `build_html` (rendering, escaping, empty state), `fetch_recent_shows` (deduplication, 5-show limit) |
+| `tests/test_feed_builders.py` | All feed builders | `github_block`, `mlb_block`, `letterboxd_block`, `goodreads_reading_block`, `goodreads_block`, `fbst_block`, `plex build_html` — mocked network |
+| `tests/test_spotify.py` | `bin/update-spotify.py` | `build_html`, `load_state`/`save_state`, `fetch_recent_tracks`, `fetch_current_podcast` |
+| `tests/test_whoop.py` | `bin/update-whoop.py` | `fetch_latest_recovery`/`sleep`/`cycle`, `build_html` with all recovery color thresholds |
 
 ### E2E Tests (`tests/test_site_e2e.py`)
 
@@ -74,4 +77,4 @@ python3 -m pytest tests/test_site_e2e.py -v
 
 Tests run in CI via `.github/workflows/ci-tests.yml`. Results are visible in the GitHub Actions tab. Failures block nothing (this is a single-contributor repo with direct push), but they surface regressions early.
 
-Last updated: 2026-04-21
+Last updated: 2026-04-22

--- a/llms.txt
+++ b/llms.txt
@@ -27,6 +27,7 @@ The site includes a Derek Sivers-style /now page at https://jameschang.co/now/ w
 - Goodreads: recently read books
 - The Fantastic Leagues: fantasy baseball team standings
 - Trakt (every 6 hours): recently watched TV shows
+- Plex (every 6 hours): recently watched movies and TV from home server
 - Thirsty Pig hit list: restaurants to try (client-side fetch)
 
 The /now page also lists active projects, back-burner work, and what James is currently exploring (Obsidian integration, OpenClaw).


### PR DESCRIPTION
## Summary
- docs/test-plan.md: added 3 missing test files (46 tests undocumented)
- llms.txt: added Plex feed
- README.md: 8→11 feeds, added test count + GA4/GSC

## Drift fixed
All drift found via `/doc` sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)