### PR TITLE
fix(/now): drop stripped PR events instead of rendering dead '(untitled)' links

### DIFF
--- a/bin/update-projects.py
+++ b/bin/update-projects.py
@@ -119,10 +119,17 @@ def parse_events(events, token):
             entry["_head_sha"] = sha
         elif etype == "PullRequestEvent":
             pr = payload.get("pull_request") or {}
+            html_url = pr.get("html_url")
+            title = pr.get("title")
+            # Public-events endpoint strips payload.pull_request for private-
+            # repo events, leaving no URL or title. The merge commit still
+            # arrives as a PushEvent with full data, so dropping these loses
+            # nothing and avoids rendering "(untitled)" dead links.
+            if not html_url or not title:
+                continue
             action = payload.get("action", "")
-            title = pr.get("title") or "(untitled)"
             entry["summary"] = f"PR {action}: {title}"
-            entry["url"] = pr.get("html_url")
+            entry["url"] = html_url
         elif etype == "ReleaseEvent":
             rel = payload.get("release") or {}
             entry["summary"] = f"Released {rel.get('tag_name', '')}"

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -63,3 +63,62 @@ class TestLoadConfig:
             assert "repo" in project
             assert "file" in project
             assert project["repo"].startswith("thirstypig/")
+
+
+class TestParseEventsPullRequest:
+    """PR events with stripped payloads (private-repo sanitization) must be
+    dropped so readers never see 'PR opened: (untitled)' linking to '#'."""
+
+    @staticmethod
+    def _now_iso():
+        from datetime import datetime, timezone
+        return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    def _pr_event(self, *, title, html_url, action="opened"):
+        return {
+            "type": "PullRequestEvent",
+            "created_at": self._now_iso(),
+            "repo": {"name": "thirstypig/demo"},
+            "payload": {
+                "action": action,
+                "pull_request": {"title": title, "html_url": html_url},
+            },
+        }
+
+    def test_keeps_pr_event_with_full_payload(self):
+        events = [self._pr_event(title="Fix bug", html_url="https://github.com/x/pull/1")]
+        result = _projects.parse_events(events, token=None)
+        assert "thirstypig/demo" in result
+        entry = result["thirstypig/demo"][0]
+        assert entry["summary"] == "PR opened: Fix bug"
+        assert entry["url"] == "https://github.com/x/pull/1"
+
+    def test_drops_pr_event_with_stripped_payload(self):
+        """Private-repo PR events arrive with null title + null html_url."""
+        events = [self._pr_event(title=None, html_url=None)]
+        result = _projects.parse_events(events, token=None)
+        assert result == {} or result.get("thirstypig/demo", []) == []
+
+    def test_drops_pr_event_missing_url_only(self):
+        events = [self._pr_event(title="Has title", html_url=None)]
+        result = _projects.parse_events(events, token=None)
+        assert result.get("thirstypig/demo", []) == []
+
+    def test_drops_pr_event_missing_title_only(self):
+        events = [self._pr_event(title=None, html_url="https://example/pr/1")]
+        result = _projects.parse_events(events, token=None)
+        assert result.get("thirstypig/demo", []) == []
+
+    def test_keeps_healthy_push_event_alongside(self):
+        """Regression guard: filtering PR events must not affect PushEvents."""
+        push = {
+            "type": "PushEvent",
+            "created_at": self._now_iso(),
+            "repo": {"name": "thirstypig/demo"},
+            "payload": {"head": "abc123", "ref": "refs/heads/main"},
+        }
+        stripped_pr = self._pr_event(title=None, html_url=None)
+        result = _projects.parse_events([push, stripped_pr], token=None)
+        entries = result["thirstypig/demo"]
+        assert len(entries) == 1
+        assert entries[0]["url"] == "https://github.com/thirstypig/demo/commit/abc123"


### PR DESCRIPTION
## Summary
- The `/now` page's shipping list was rendering `<a href="#">PR opened: (untitled)</a>` for three projects (Fantastic Leagues, Tastemakers, Thirsty Pig) — dead links with no reader value.
- Root cause: `/users/{user}/events/public` strips `payload.pull_request` (title + `html_url`) on private-repo events. The merge-commit `PushEvent` for the same PR already shows up with full data and its own enrichment pass, so dropping the stripped PR events loses nothing.
- Fix: in `parse_events`, skip `PullRequestEvent` entries when either `html_url` or `title` is missing.

## Before → After
Before (live after yesterday's sync):
> Merge pull request #117 from thirstypig/feat/… · 56m ago · **PR merged: (untitled)** · 56m ago

After (this PR):
> Merge pull request #117 from thirstypig/feat/… · 56m ago

## Tests
- 5 new tests in `tests/test_projects.py::TestParseEventsPullRequest`
  - `test_keeps_pr_event_with_full_payload`
  - `test_drops_pr_event_with_stripped_payload`
  - `test_drops_pr_event_missing_url_only`
  - `test_drops_pr_event_missing_title_only`
  - `test_keeps_healthy_push_event_alongside` (regression guard)
- Full suite: 153/153 passing (was 148).

## Test plan
- [x] Unit tests cover happy path + all three "stripped" variants + PushEvent regression
- [x] Full test suite green locally (`python3 -m pytest tests/` → 153 passed)
- [x] Pre-commit hook ran the suite on commit
- [ ] Post-merge: trigger `projects-sync.yml` manually, verify shipping list has no `href="#"` anchors

🤖 Generated with [Claude Code](https://claude.com/claude-code)