### PR TITLE
feat(/now): live-relative timestamps via progressive enhancement

### DIFF
--- a/bin/_shared.py
+++ b/bin/_shared.py
@@ -100,6 +100,28 @@ def relative_time(iso_str):
     return f"{months}mo ago"
 
 
+def relative_time_html(iso_str):
+    """Return a <time datetime="..." data-rel> element for live-relative display.
+
+    The server-rendered text (e.g. '7m ago') is the initial/no-JS fallback;
+    the inline upgrader script in now/index.html recomputes textContent on
+    page load and every minute thereafter, so the label stays truthful even
+    when the last sync ran hours ago. Returns empty string for invalid input.
+    """
+    label = relative_time(iso_str)
+    if not label or not iso_str:
+        return ""
+    # Normalize the datetime attribute to a UTC ISO-8601 string with Z suffix
+    # so Date.parse() in the browser gets an unambiguous value.
+    iso_norm = iso_str[:-1] + "+00:00" if iso_str.endswith("Z") else iso_str
+    try:
+        t_utc = datetime.fromisoformat(iso_norm).astimezone(timezone.utc)
+    except ValueError:
+        return ""
+    stamp = t_utc.strftime("%Y-%m-%dT%H:%M:%SZ")
+    return f'<time datetime="{stamp}" data-rel>{label}</time>'
+
+
 def replace_marker(content, marker_name, html):
     """Replace <!-- {MARKER}-START -->...<!-- {MARKER}-END --> in content.
 

--- a/bin/update-projects.py
+++ b/bin/update-projects.py
@@ -34,7 +34,7 @@ from _shared import (
     format_update_time,
     read_now_html,
     record_heartbeat,
-    relative_time,
+    relative_time_html,
     replace_marker,
     write_now_html,
     REPO_ROOT,
@@ -179,7 +179,7 @@ def render_shipping_list(events):
     for ev in events:
         summary = escape_html(ev["summary"])[:90]
         url = escape_html(ev["url"] or "#")
-        when = relative_time(ev["time"])
+        when = relative_time_html(ev["time"])
         items.append(f'<a href="{url}" rel="noopener" target="_blank">{summary}</a> <span class="gh-when">&middot; {when}</span>')
     return (
         '          <p class="shipping-recent"><strong>Recently shipped:</strong> '

--- a/bin/update-spotify.py
+++ b/bin/update-spotify.py
@@ -21,7 +21,7 @@ from urllib.request import Request, urlopen
 
 from _shared import (
     escape_html,
-    relative_time,
+    relative_time_html,
     replace_marker,
     record_heartbeat,
     sanitize_error,
@@ -144,7 +144,7 @@ def build_html(tracks, podcast):
         show = podcast.get("show") or ""
         episode = podcast.get("episode") or ""
         url = podcast.get("url")
-        captured = relative_time(podcast.get("captured_at"))
+        captured = relative_time_html(podcast.get("captured_at"))
         label_html = f'<em>{escape_html(show)}</em> &mdash; &ldquo;{escape_html(episode)}&rdquo;'
         if url:
             label_html = f'<a href="{escape_html(url)}" rel="noopener" target="_blank">{label_html}</a>'
@@ -157,7 +157,7 @@ def build_html(tracks, podcast):
         for t in tracks:
             name = escape_html(t["name"])
             artists = escape_html(t["artists"])
-            played = relative_time(t.get("played_at"))
+            played = relative_time_html(t.get("played_at"))
             title_html = f'&ldquo;{name}&rdquo; &mdash; {artists}'
             if t.get("url"):
                 title_html = f'<a href="{escape_html(t["url"])}" rel="noopener" target="_blank">{title_html}</a>'

--- a/bin/update-trakt.py
+++ b/bin/update-trakt.py
@@ -18,7 +18,7 @@ from urllib.request import Request, urlopen
 
 from _shared import (
     escape_html,
-    relative_time,
+    relative_time_html,
     replace_marker,
     record_heartbeat,
     sanitize_error,
@@ -171,7 +171,7 @@ def build_html(shows):
             title_html = f'{show_name}{ep_label}'
             if s.get("url"):
                 title_html = f'<a href="{escape_html(s["url"])}" rel="noopener" target="_blank">{title_html}</a>'
-            watched = relative_time(s.get("watched_at"))
+            watched = relative_time_html(s.get("watched_at"))
             parts.append(f'          <li>{title_html} <span class="trakt-when">&middot; {watched}</span></li>')
         parts.append('        </ul>')
     else:

--- a/now/index.html
+++ b/now/index.html
@@ -526,5 +526,39 @@
       }
     })();
   </script>
+  <script>
+    // Live-relative time upgrader. Every <time data-rel> in the page was
+    // server-rendered with a stale "Nm ago" label at sync time; this script
+    // recomputes the label from the datetime attribute at view time and
+    // refreshes it every minute so the page never shows yesterday's number.
+    (function () {
+      function fmt(ms) {
+        var m = Math.floor(ms / 60000);
+        if (m < 1) return 'just now';
+        if (m < 60) return m + 'm ago';
+        var h = Math.floor(m / 60);
+        if (h < 24) return h + 'h ago';
+        var d = Math.floor(h / 24);
+        if (d === 1) return 'yesterday';
+        if (d < 7) return d + 'd ago';
+        var w = Math.floor(d / 7);
+        if (w < 5) return w + 'w ago';
+        return Math.floor(d / 30) + 'mo ago';
+      }
+      function tick() {
+        var now = Date.now();
+        document.querySelectorAll('time[data-rel]').forEach(function (el) {
+          var t = Date.parse(el.getAttribute('datetime'));
+          if (!isNaN(t)) el.textContent = fmt(now - t);
+        });
+      }
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', tick);
+      } else {
+        tick();
+      }
+      setInterval(tick, 60000);
+    })();
+  </script>
 </body>
 </html>

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -14,6 +14,7 @@ from _shared import (
     escape_html,
     record_heartbeat,
     relative_time,
+    relative_time_html,
     replace_marker,
     sanitize_error,
 )
@@ -99,6 +100,56 @@ class TestRelativeTime:
         from datetime import datetime, timedelta, timezone
         sixty_days = (datetime.now(timezone.utc) - timedelta(days=60)).isoformat()
         assert relative_time(sixty_days) == "2mo ago"
+
+
+# ── relative_time_html ───────────────────────────────────────────
+
+class TestRelativeTimeHtml:
+    """Progressive-enhancement helper: wraps relative_time in a <time
+    datetime="..." data-rel> element so client-side JS can recompute the
+    label at view time instead of freezing it at sync time."""
+
+    def test_returns_empty_on_empty_input(self):
+        assert relative_time_html("") == ""
+        assert relative_time_html(None) == ""
+
+    def test_returns_empty_on_invalid_input(self):
+        assert relative_time_html("not-a-date") == ""
+
+    def test_wraps_recent_time_in_time_element(self):
+        from datetime import datetime, timedelta, timezone
+        recent = (datetime.now(timezone.utc) - timedelta(minutes=7)).isoformat()
+        out = relative_time_html(recent)
+        assert out.startswith('<time datetime="')
+        assert 'data-rel' in out
+        assert '>7m ago</time>' in out
+
+    def test_normalizes_datetime_to_utc_z_suffix(self):
+        """The datetime attribute must be parseable by Date.parse() unambiguously."""
+        # Input with explicit +00:00 offset should normalize to Z.
+        iso_with_offset = "2026-04-22T19:50:00+00:00"
+        out = relative_time_html(iso_with_offset)
+        assert 'datetime="2026-04-22T19:50:00Z"' in out
+
+    def test_normalizes_z_suffix_input(self):
+        iso_z = "2026-04-22T19:50:00Z"
+        out = relative_time_html(iso_z)
+        assert 'datetime="2026-04-22T19:50:00Z"' in out
+
+    def test_converts_non_utc_offset_to_utc(self):
+        """A Pacific-offset input should serialize as the equivalent UTC moment."""
+        iso_pdt = "2026-04-22T12:50:00-07:00"  # = 19:50:00 UTC
+        out = relative_time_html(iso_pdt)
+        assert 'datetime="2026-04-22T19:50:00Z"' in out
+
+    def test_label_matches_plain_relative_time(self):
+        """The inner textContent must equal relative_time() output exactly —
+        it's the no-JS fallback, so parity matters."""
+        from datetime import datetime, timedelta, timezone
+        t = (datetime.now(timezone.utc) - timedelta(hours=3)).isoformat()
+        html = relative_time_html(t)
+        plain = relative_time(t)
+        assert f'>{plain}</time>' in html
 
 
 # ── replace_marker ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Relative-time labels (\"7m ago\", \"2h ago\") on /now were computed at sync time and frozen in static HTML. Between syncs they drifted — a Spotify track synced at 7:50pm still said \"7m ago\" at 9:50pm.
- Fix: server-render each label as a \`<time datetime=\"...\" data-rel>\` element, then upgrade \`textContent\` client-side on DOMContentLoaded and every 60 seconds.

## Files
- **\`bin/_shared.py\`** — new \`relative_time_html()\` helper. Emits \`<time datetime=\"2026-04-22T19:50:00Z\" data-rel>7m ago</time>\`. Datetime attribute normalized to UTC with \`Z\` suffix so \`Date.parse()\` in the browser is unambiguous.
- **\`bin/update-spotify.py\`** — uses the HTML helper for podcast \"heard\" and track \"played\" labels.
- **\`bin/update-trakt.py\`** — uses the HTML helper for \"watched\" labels.
- **\`bin/update-projects.py\`** — uses the HTML helper for per-project shipping \"ago\" stamps.
- **\`now/index.html\`** — inline upgrader \`<script>\` at the bottom. Mirrors Python \`relative_time()\` semantics exactly (min/hour/yesterday/day/week/month thresholds).
- **\`tests/test_shared.py\`** — 7 new tests covering:
  - empty / None / invalid input → empty string
  - UTC normalization from \`+00:00\` offset → \`Z\` suffix
  - UTC normalization from Pacific \`-07:00\` offset
  - \`Z\` suffix input preserved
  - inner text content matches \`relative_time()\` exactly (no-JS parity)

## Progressive enhancement guarantees
- **No JS?** You still see a valid \"Nm ago\" label. Just potentially stale (exactly what you see today).
- **JS on?** Label is truthful to the minute, regardless of when the last sync ran.
- **Crawlers?** See the \`<time datetime=\"...\">\` element, which is semantically correct and machine-readable.
- **Screen readers?** Get the ISO timestamp via the \`datetime\` attribute.

## Tests
- 160/160 passing (was 153)
- No existing feed-builder tests assert on \"Nm ago\" strings, so the rollover was clean.

## Test plan
- [x] Unit tests cover helper behavior + UTC normalization + fallback parity
- [x] Full suite green locally (160 passed in 1.6s)
- [x] Pre-commit hook ran the suite on commit
- [ ] Post-merge: trigger next Spotify / Trakt sync, confirm \`<time data-rel>\` elements appear in \`now/index.html\` and update live in a browser
- [ ] Post-merge: leave the page open for 2+ minutes and watch the labels tick forward

🤖 Generated with [Claude Code](https://claude.com/claude-code)