### PR TITLE
fix(/now): capture podcast from recently-played history, not just currently-playing

### DIFF
--- a/bin/update-spotify.py
+++ b/bin/update-spotify.py
@@ -102,21 +102,44 @@ def save_state(state):
         f.write("\n")
 
 
-def fetch_recent_tracks(token):
-    """Return list of last N music tracks, each as {name, artists, played_at}."""
-    data = api_get(token, "/me/player/recently-played", {"limit": str(TRACKS_LIMIT)})
+def fetch_recent_plays(token):
+    """Return (tracks, episodes) from /me/player/recently-played.
+
+    Without additional_types=episode, Spotify's recently-played endpoint
+    returns tracks only — podcast plays are silently dropped. That left
+    the "Last podcast" line dependent on /me/player/currently-playing,
+    which only fires if a podcast is actively playing at cron time.
+    Most episode plays were missed.
+
+    With additional_types=episode we get tracks AND episodes in one
+    response (up to 50 items), each with a real played_at timestamp.
+    The client must inspect item.track.type to tell them apart.
+    """
+    data = api_get(token, "/me/player/recently-played", {
+        "limit": "50",
+        "additional_types": "episode",
+    })
     if not data:
-        return []
-    out = []
+        return [], []
+    tracks, episodes = [], []
     for item in data.get("items", []):
-        track = item.get("track") or {}
-        out.append({
-            "name": track.get("name", "(unknown)"),
-            "artists": ", ".join(a.get("name", "") for a in track.get("artists", [])),
-            "played_at": item.get("played_at"),
-            "url": (track.get("external_urls") or {}).get("spotify"),
-        })
-    return out
+        inner = item.get("track") or {}
+        played_at = item.get("played_at")
+        if inner.get("type") == "episode":
+            episodes.append({
+                "episode": inner.get("name"),
+                "show": (inner.get("show") or {}).get("name"),
+                "url": (inner.get("external_urls") or {}).get("spotify"),
+                "captured_at": played_at,
+            })
+        else:
+            tracks.append({
+                "name": inner.get("name", "(unknown)"),
+                "artists": ", ".join(a.get("name", "") for a in inner.get("artists", [])),
+                "played_at": played_at,
+                "url": (inner.get("external_urls") or {}).get("spotify"),
+            })
+    return tracks[:TRACKS_LIMIT], episodes
 
 
 def fetch_current_podcast(token):
@@ -178,18 +201,27 @@ def build_html(tracks, podcast):
 def main():
     token = get_access_token()
 
-    tracks = fetch_recent_tracks(token)
+    tracks, episodes = fetch_recent_plays(token)
     current = fetch_current_podcast(token)
 
     state = load_state()
     podcast = state.get("last_podcast")
     state_dirty = False
 
-    if current:
+    # Prefer the most recent episode from listening history (real play
+    # timestamp, captures episodes even if playback has since stopped).
+    # Fall back to currently-playing (real-time snapshot) and then to
+    # cached state (stale up to PODCAST_AGE_LIMIT).
+    if episodes:
+        podcast = episodes[0]
+        state["last_podcast"] = podcast
+        state_dirty = True
+        print(f"Captured podcast from history: {podcast['show']} — {podcast['episode']}")
+    elif current:
         podcast = current
         state["last_podcast"] = podcast
         state_dirty = True
-        print(f"Captured podcast: {current['show']} — {current['episode']}")
+        print(f"Captured podcast from currently-playing: {current['show']} — {current['episode']}")
     elif podcast:
         try:
             captured = datetime.fromisoformat(podcast["captured_at"].replace("Z", "+00:00"))

--- a/tests/test_spotify.py
+++ b/tests/test_spotify.py
@@ -11,7 +11,7 @@ _spotify = importlib.import_module("update-spotify")
 build_html = _spotify.build_html
 load_state = _spotify.load_state
 save_state = _spotify.save_state
-fetch_recent_tracks = _spotify.fetch_recent_tracks
+fetch_recent_plays = _spotify.fetch_recent_plays
 fetch_current_podcast = _spotify.fetch_current_podcast
 
 
@@ -90,15 +90,22 @@ class TestSpotifyState:
         assert load_state() == {}
 
 
-# ── fetch_recent_tracks ──────────────────────────────────────────
+# ── fetch_recent_plays ───────────────────────────────────────────
 
-class TestFetchRecentTracks:
-    def test_parses_api_response(self, monkeypatch):
+class TestFetchRecentPlays:
+    """Returns (tracks, episodes) from recently-played. Items are
+    distinguished by track.type — 'track' items go to tracks list,
+    'episode' items go to episodes list. Episodes require the
+    additional_types=episode param to be sent (server-side filter
+    otherwise drops them from the response)."""
+
+    def test_parses_track_item(self, monkeypatch):
         fake_response = {
             "items": [
                 {
                     "track": {
                         "name": "Espresso",
+                        "type": "track",
                         "artists": [{"name": "Sabrina Carpenter"}],
                         "external_urls": {"spotify": "https://spotify.com/track/abc"},
                     },
@@ -107,15 +114,82 @@ class TestFetchRecentTracks:
             ]
         }
         monkeypatch.setattr(_spotify, "api_get", lambda token, path, params=None: fake_response)
-        tracks = fetch_recent_tracks("fake_token")
+        tracks, episodes = fetch_recent_plays("fake_token")
         assert len(tracks) == 1
+        assert episodes == []
         assert tracks[0]["name"] == "Espresso"
         assert tracks[0]["artists"] == "Sabrina Carpenter"
         assert tracks[0]["url"] == "https://spotify.com/track/abc"
+        assert tracks[0]["played_at"] == "2026-04-20T12:00:00Z"
+
+    def test_parses_episode_item(self, monkeypatch):
+        fake_response = {
+            "items": [
+                {
+                    "track": {
+                        "name": "The Ezra Klein Show",
+                        "type": "episode",
+                        "show": {"name": "The Ezra Klein Show"},
+                        "external_urls": {"spotify": "https://spotify.com/episode/xyz"},
+                    },
+                    "played_at": "2026-04-21T09:00:00Z",
+                }
+            ]
+        }
+        monkeypatch.setattr(_spotify, "api_get", lambda token, path, params=None: fake_response)
+        tracks, episodes = fetch_recent_plays("fake_token")
+        assert tracks == []
+        assert len(episodes) == 1
+        assert episodes[0]["show"] == "The Ezra Klein Show"
+        assert episodes[0]["episode"] == "The Ezra Klein Show"
+        assert episodes[0]["captured_at"] == "2026-04-21T09:00:00Z"
+        assert episodes[0]["url"] == "https://spotify.com/episode/xyz"
+
+    def test_splits_mixed_response(self, monkeypatch):
+        """A typical response interleaves tracks and episodes."""
+        fake_response = {
+            "items": [
+                {"track": {"name": "Song A", "type": "track", "artists": [{"name": "Artist"}], "external_urls": {}}, "played_at": "2026-04-22T10:00:00Z"},
+                {"track": {"name": "Ep 1", "type": "episode", "show": {"name": "Show A"}, "external_urls": {}}, "played_at": "2026-04-22T09:00:00Z"},
+                {"track": {"name": "Song B", "type": "track", "artists": [{"name": "Artist"}], "external_urls": {}}, "played_at": "2026-04-22T08:00:00Z"},
+            ]
+        }
+        monkeypatch.setattr(_spotify, "api_get", lambda token, path, params=None: fake_response)
+        tracks, episodes = fetch_recent_plays("fake_token")
+        assert len(tracks) == 2
+        assert len(episodes) == 1
+        assert tracks[0]["name"] == "Song A"
+        assert tracks[1]["name"] == "Song B"
+        assert episodes[0]["show"] == "Show A"
 
     def test_empty_response(self, monkeypatch):
         monkeypatch.setattr(_spotify, "api_get", lambda token, path, params=None: None)
-        assert fetch_recent_tracks("fake") == []
+        assert fetch_recent_plays("fake") == ([], [])
+
+    def test_slices_tracks_to_display_limit(self, monkeypatch):
+        """Tracks list is capped at TRACKS_LIMIT (5) for display; episodes
+        list is unsliced so main() can pick the most recent."""
+        items = [
+            {"track": {"name": f"Song {i}", "type": "track", "artists": [{"name": "A"}], "external_urls": {}}, "played_at": f"2026-04-22T{10+i:02d}:00:00Z"}
+            for i in range(10)
+        ]
+        monkeypatch.setattr(_spotify, "api_get", lambda token, path, params=None: {"items": items})
+        tracks, episodes = fetch_recent_plays("fake_token")
+        assert len(tracks) == _spotify.TRACKS_LIMIT
+        assert episodes == []
+
+    def test_requests_additional_types_episode(self, monkeypatch):
+        """Regression guard: without additional_types=episode, the response
+        drops podcast plays entirely. Verify the param is being sent."""
+        captured_params = {}
+
+        def fake_api_get(token, path, params=None):
+            captured_params.update(params or {})
+            return {"items": []}
+
+        monkeypatch.setattr(_spotify, "api_get", fake_api_get)
+        fetch_recent_plays("fake_token")
+        assert captured_params.get("additional_types") == "episode"
 
 
 # ── fetch_current_podcast ────────────────────────────────────────


### PR DESCRIPTION
## Summary
Podcast line was going stale because \`fetch_current_podcast\` only returned a result when a podcast was *actively playing* at the moment the 4h cron fired. Finished episodes between syncs → missed.

Fix: request \`/me/player/recently-played\` with \`additional_types=episode\` (up to 50 items of mixed tracks + episodes, each with a real \`played_at\` timestamp) and prefer the most recent episode from history. Currently-playing stays as a secondary capture path.

## Capture priority (new)
1. **Most recent episode from recently-played** (real \`played_at\` timestamp, catches episodes completed hours ago)
2. **Currently-playing** (real-time snapshot, covers active listening)
3. **Cached state** (stale, bounded by \`PODCAST_AGE_LIMIT=7d\`)

## Bonus
Podcast \"heard Nh ago\" now reflects the real listening time, not \`datetime.now()\` at sync time. Pairs with PR #11's live-relative timestamps.

## Tests
- 6 new in \`TestFetchRecentPlays\`: track parsing, episode parsing, mixed split, empty response, \`TRACKS_LIMIT\` slicing, \`additional_types=episode\` param regression guard
- 164/164 passing (was 160)

## Test plan
- [x] Unit tests cover both item types + mixed + empty + param guard
- [x] Full suite green locally
- [ ] Post-merge: trigger Spotify sync, confirm a recent podcast episode (not the 5-day-old Buster Olney one) appears in the \"Last podcast:\" line

🤖 Generated with [Claude Code](https://claude.com/claude-code)